### PR TITLE
Adding dedicated career guide

### DIFF
--- a/career.tex
+++ b/career.tex
@@ -14,10 +14,10 @@
 \section{Common Technical Skills}
 \begin{itemize}
 \item Know the UNIX shell
-\item Learn a CLI editor (vim, nano, emacs, etc)
+\item Learn a CLI editor (vim, Nano, Emacs, etc)
 \item Know at least one flavor of SQL
-\item Know at least one source control (ie Git)
-\item Know at least one CI/CD (ie Jenkins)
+\item Know at least one source control (IE Git)
+\item Know at least one CI/CD (IE Jenkins)
 \end{itemize}
 
 \section{Core Software Development}
@@ -70,13 +70,13 @@
   \item SCaLE
   \item Reinvent
   \item Layer 1
-  \item Defcon
-  \item Blackhat
-  \item Hashiconf
-  \item Sparklecon
+  \item DEF CON
+  \item Black Hat
+  \item HashiConf
+  \item SparkleCon
   \item DevOps Summit
   \item PyCon
-  \item Rustconf
+  \item RustConf
   \end{itemize}
 \end{itemize}
 
@@ -85,9 +85,9 @@ For most of software engineering, the demand for engineers exceeds the supply. I
 \begin{itemize}
 \item Prepare for a 25\% to 50\% salary cut vs what you could get in other entry level software development jobs. That is not a typo
 \item Game programming is not game design. Game programmers usually get very little creative input in how the game is made
-\item No, your platformer made in Unity is not enough. You need a stong understanding of lower level programming in C++
+\item No, your platformer made in Unity is not enough. You need a strong understanding of lower level programming in C++
 \item Your friend who got a job with just a Unity platformer got lucky. Don't bet on yourself getting lucky, too
-\item The gaming industry only gives internships to students from top ranked schools (like USC) or to students with adjacent work experience (ie C++/graphics/Objective-C/Android-JNI development)
+\item The gaming industry only gives internships to students from top ranked schools (like USC) or to students with adjacent work experience (IE C++/graphics/Objective-C/Android-JNI development)
 \item Most people get in by slogging through QA. Some move from adjacent software engineering jobs. Few get in directly by networking directly into game programming jobs
 \item Game programming jobs are unstable. Don't expect your first job to last you a year
 \item Layoffs are always around the corner. Always have 6 months of expenses saved up
@@ -98,6 +98,6 @@ For most of software engineering, the demand for engineers exceeds the supply. I
 \item Game programming salaries eventually catch up to other software engineering salaries if you have the skills to back it up. Most people don't. Never stop researching
 \item Crunch happens but it should not be the norm. If the studio is not making any effort to avoid crunch, get out 
 \item Always make sure you can walk away from a job in case you need/have to
-\item Game programming skills often don't carry over to in demand positions (fullstack, frontend, backend, devops, etc). It may be difficult to leave if you don't want to be in the gaming industry anymore
+\item Game programming skills often don't carry over to in demand positions (fullstack, frontend, backend, DevOps, etc). It may be difficult to leave if you don't want to be in the gaming industry anymore
 \end{itemize}
 \end{document}

--- a/career.tex
+++ b/career.tex
@@ -1,0 +1,105 @@
+\documentclass[12pt]{article}
+\usepackage[top=1in, bottom=1in, left=1in, right=1in]{geometry}
+\usepackage{hyperref}
+\usepackage{ifpdf}
+
+\title{Code and Coffee General Career Guide}
+\author{Code and Coffee}
+\date{\today}
+
+\begin{document}
+
+\maketitle
+
+\section{Common Technical Skills}
+\begin{itemize}
+\item Know the UNIX shell
+\item Learn a CLI editor (vim, nano, emacs, etc)
+\item Know at least one flavor of SQL
+\item Know at least one source control (ie Git)
+\item Know at least one CI/CD (ie Jenkins)
+\end{itemize}
+
+\section{Core Software Development}
+\begin{itemize}
+\item \textbf{Cracking the Coding Interview} McDowell
+\item \textbf{The Algorithm Design Manual} Skiena
+\item \textbf{Design Patterns} Gamma, Helm, Johnson, Booch
+\item Learn the basics of Agile
+\item A ticketing system like JIRA or Trello
+\end{itemize}
+
+
+\section{Getting the Job}
+\begin{itemize}
+\item Research positions way in advance before applying (Position requirements, interview questions)
+\item Research the specific company you are applying to
+\item Balance what's in demand vs what you like to do
+\item Find examples of resumes and research how to make a resume
+\item Set up a Linked in
+\item Set up a \textit{professional} website
+\item Have an online Git and make sure to show off only your best work
+\item Make a professional business card
+\item Know the 6 month time limit
+\item Network
+\item Always be working on something
+\end{itemize}
+
+\section{Career Advice}
+\begin{itemize}
+\item Watch out for recruiters
+  \begin{itemize}
+  \item Watch out for 3rd party recruiters
+    \begin{itemize}
+    \item They sell data to third parties
+    \item They bait and switch
+    \item They take commission (18\%-30\%) which lowers your pay
+      negotiation
+    \end{itemize}
+  \item They are not programmers and do not know technical details
+  \item Watch out for foreign agencies
+  \item Make your salary requirements clear and firm
+  \end{itemize}
+\item Never stop researching. You should still have side projects
+  after getting in.
+\item Watch for IP agreements in your contract
+\item Get advice from more senior engineers
+\item Get contract jobs reviewed by a lawyer
+\item Go to hackerspaces
+\item Document issues with difficult coworkers
+\item Go to conferences
+  \begin{itemize}
+    \item SCaLE
+    \item Reinvent
+    \item Layer 1
+    \item Defcon
+    \item Blackhat
+    \item Hashiconf
+    \item Sparklecon
+    \item DevOps Summit
+    \item PyCon
+    \item Rustconf
+  \end{itemize}
+\end{itemize}
+
+\section{The Gaming Industry is the Exception}
+For most of software engineering, the demand for engineers exceeds the supply. In game programming, the supply exceeds the demand. This means the gaming industry plays by a different set of rules where engineers have much less leverage.
+\begin{itemize}
+  \item Prepare for a 25\% to 50\% salary cut vs what you could get in other entry level software development jobs. That is not a typo
+  \item Game programming is not game design. Game programmers usually get very little creative input in how the game is made
+  \item No, your platformer made in Unity is not enough. You need a stong understanding of lower level programming in C++
+  \item Your friend who got a job with just a Unity platformer got lucky. Don't bet on yourself getting lucky, too
+  \item The gaming industry only gives internships to students from top ranked schools (like USC) or to students with adjacent work experience (ie C++/graphics/Objective-C/Android-JNI development)
+  \item Most people get in by slogging through QA. Some move from adjacent software engineering jobs. Few get in directly by networking directly into game programming jobs
+  \item Game programming jobs are unstable. Don't expect your first job to last you a year
+  \item Layoffs are always around the corner. Always have 6 months of expenses saved up
+  \item You may get hired for a project that never gets started. It's not rare for someone to get hired and then get laid off weeks later because the project they were working on got canceled
+  \item Specialize. Specialists get treated better.
+  \item Just because you made it in does not mean you will last. The average time in the game industry for an engineer is about 5 years. Never stop researching to keep your skills sharp
+  \item Interviews get harder the longer you last in the industry. Never stop researching
+  \item Game programming salaries eventually catch up to other software engineering salaries if you have the skills to back it up. Most people don't. Never stop researching
+  \item Crunch happens but it should not be the norm. If the studio is not making any effort to avoid crunch, get out 
+  \item Always make sure you can walk away from a job in case you need/have to
+  \item Game programming skills often don't carry over to in demand positions (fullstack, frontend, backend, devops, etc). It may be difficult to leave if you don't want to be in the gaming industry anymore
+\end{itemize}
+\end{document}

--- a/career.tex
+++ b/career.tex
@@ -53,15 +53,13 @@
     \begin{itemize}
     \item They sell data to third parties
     \item They bait and switch
-    \item They take commission (18\%-30\%) which lowers your pay
-      negotiation
+    \item They take commission (18\%-30\%) which lowers your pay negotiation
     \end{itemize}
   \item They are not programmers and do not know technical details
   \item Watch out for foreign agencies
   \item Make your salary requirements clear and firm
   \end{itemize}
-\item Never stop researching. You should still have side projects
-  after getting in.
+\item Never stop researching. You should still have side projects after getting in.
 \item Watch for IP agreements in your contract
 \item Get advice from more senior engineers
 \item Get contract jobs reviewed by a lawyer
@@ -69,37 +67,37 @@
 \item Document issues with difficult coworkers
 \item Go to conferences
   \begin{itemize}
-    \item SCaLE
-    \item Reinvent
-    \item Layer 1
-    \item Defcon
-    \item Blackhat
-    \item Hashiconf
-    \item Sparklecon
-    \item DevOps Summit
-    \item PyCon
-    \item Rustconf
+  \item SCaLE
+  \item Reinvent
+  \item Layer 1
+  \item Defcon
+  \item Blackhat
+  \item Hashiconf
+  \item Sparklecon
+  \item DevOps Summit
+  \item PyCon
+  \item Rustconf
   \end{itemize}
 \end{itemize}
 
 \section{The Gaming Industry is the Exception}
 For most of software engineering, the demand for engineers exceeds the supply. In game programming, the supply exceeds the demand. This means the gaming industry plays by a different set of rules where engineers have much less leverage.
 \begin{itemize}
-  \item Prepare for a 25\% to 50\% salary cut vs what you could get in other entry level software development jobs. That is not a typo
-  \item Game programming is not game design. Game programmers usually get very little creative input in how the game is made
-  \item No, your platformer made in Unity is not enough. You need a stong understanding of lower level programming in C++
-  \item Your friend who got a job with just a Unity platformer got lucky. Don't bet on yourself getting lucky, too
-  \item The gaming industry only gives internships to students from top ranked schools (like USC) or to students with adjacent work experience (ie C++/graphics/Objective-C/Android-JNI development)
-  \item Most people get in by slogging through QA. Some move from adjacent software engineering jobs. Few get in directly by networking directly into game programming jobs
-  \item Game programming jobs are unstable. Don't expect your first job to last you a year
-  \item Layoffs are always around the corner. Always have 6 months of expenses saved up
-  \item You may get hired for a project that never gets started. It's not rare for someone to get hired and then get laid off weeks later because the project they were working on got canceled
-  \item Specialize. Specialists get treated better.
-  \item Just because you made it in does not mean you will last. The average time in the game industry for an engineer is about 5 years. Never stop researching to keep your skills sharp
-  \item Interviews get harder the longer you last in the industry. Never stop researching
-  \item Game programming salaries eventually catch up to other software engineering salaries if you have the skills to back it up. Most people don't. Never stop researching
-  \item Crunch happens but it should not be the norm. If the studio is not making any effort to avoid crunch, get out 
-  \item Always make sure you can walk away from a job in case you need/have to
-  \item Game programming skills often don't carry over to in demand positions (fullstack, frontend, backend, devops, etc). It may be difficult to leave if you don't want to be in the gaming industry anymore
+\item Prepare for a 25\% to 50\% salary cut vs what you could get in other entry level software development jobs. That is not a typo
+\item Game programming is not game design. Game programmers usually get very little creative input in how the game is made
+\item No, your platformer made in Unity is not enough. You need a stong understanding of lower level programming in C++
+\item Your friend who got a job with just a Unity platformer got lucky. Don't bet on yourself getting lucky, too
+\item The gaming industry only gives internships to students from top ranked schools (like USC) or to students with adjacent work experience (ie C++/graphics/Objective-C/Android-JNI development)
+\item Most people get in by slogging through QA. Some move from adjacent software engineering jobs. Few get in directly by networking directly into game programming jobs
+\item Game programming jobs are unstable. Don't expect your first job to last you a year
+\item Layoffs are always around the corner. Always have 6 months of expenses saved up
+\item You may get hired for a project that never gets started. It's not rare for someone to get hired and then get laid off weeks later because the project they were working on got canceled
+\item Specialize. Specialists get treated better.
+\item Just because you made it in does not mean you will last. The average time in the game industry for an engineer is about 5 years. Never stop researching to keep your skills sharp
+\item Interviews get harder the longer you last in the industry. Never stop researching
+\item Game programming salaries eventually catch up to other software engineering salaries if you have the skills to back it up. Most people don't. Never stop researching
+\item Crunch happens but it should not be the norm. If the studio is not making any effort to avoid crunch, get out 
+\item Always make sure you can walk away from a job in case you need/have to
+\item Game programming skills often don't carry over to in demand positions (fullstack, frontend, backend, devops, etc). It may be difficult to leave if you don't want to be in the gaming industry anymore
 \end{itemize}
 \end{document}

--- a/local-dictionary
+++ b/local-dictionary
@@ -21,6 +21,7 @@ distro
 Django
 DOM
 Elasticsearch
+fullstack
 frontend
 GraphQL
 hackerspace
@@ -28,6 +29,7 @@ hackerspaces
 HashiConf
 Jira
 JMeter
+JNI
 JS
 Kibana
 Kubernetes
@@ -44,6 +46,7 @@ nginx
 NOC
 NPM
 Percona
+platformer
 PowerShell
 PyCon
 RabbitMQ
@@ -64,6 +67,7 @@ syllabi
 Terraform
 Trello
 UI
+USC
 UX
 Vue
 WAF


### PR DESCRIPTION
Splitting off the career section from the devops syllabus into its own career guide. We'll augment it later